### PR TITLE
Update random token for backend API validation

### DIFF
--- a/backend/contact.test.ts
+++ b/backend/contact.test.ts
@@ -9,7 +9,7 @@ import { email_myself } from './email';
 const mockedEmailMyself = email_myself as jest.Mock;
 
 describe('contact send', () => {
-  const validToken = 'fd0kAn1zns';
+  const validToken = '6BK2tEU6Cv';
 
   beforeEach(() => {
     mockedEmailMyself.mockClear();

--- a/backend/integration.test.ts
+++ b/backend/integration.test.ts
@@ -36,7 +36,7 @@ interface ContactModule {
 }
 
 describe('Integration Tests', () => {
-  const validToken = 'fd0kAn1zns';
+  const validToken = '6BK2tEU6Cv';
   let ssmClient: MockSSMClient;
   let sesClient: MockSESClient;
   let Mailchimp: MockMailchimpType;

--- a/backend/lambda_function.test.ts
+++ b/backend/lambda_function.test.ts
@@ -9,7 +9,7 @@ import { email_myself } from './email';
 const mockedEmailMyself = email_myself as jest.Mock;
 
 describe('LambdaFunction', () => {
-  const validToken = 'fd0kAn1zns';
+  const validToken = '6BK2tEU6Cv';
 
   beforeEach(() => {
     mockedEmailMyself.mockClear();

--- a/backend/lambda_function.ts
+++ b/backend/lambda_function.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import { email_myself } from './email';
 
-const token = 'fd0kAn1zns';
+const token = '6BK2tEU6Cv';
 
 const cors_headers = {
   'Access-Control-Allow-Origin': 'https://www.cryfs.org',

--- a/backend/lambda_function.ts
+++ b/backend/lambda_function.ts
@@ -1,6 +1,14 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import { email_myself } from './email';
 
+/**
+ * Authentication token to validate requests from the frontend.
+ * Must match API_AUTH_TOKEN in frontend/config/api.ts
+ *
+ * NOTE: This does NOT provide actual security (it's visible in the client-side code).
+ * It's only meant to block naive bots and scrapers who don't know about it.
+ * Do not rely on this for authentication or authorization.
+ */
 const token = '6BK2tEU6Cv';
 
 const cors_headers = {

--- a/backend/newsletter.test.ts
+++ b/backend/newsletter.test.ts
@@ -27,7 +27,7 @@ const MockMailchimp = require('mailchimp-api-v3').default as MockMailchimpType;
 const mockedEmailMyself = email_myself as jest.Mock;
 
 describe('newsletter register', () => {
-  const validToken = 'fd0kAn1zns';
+  const validToken = '6BK2tEU6Cv';
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/frontend/components/sections/ContactSection.tsx
+++ b/frontend/components/sections/ContactSection.tsx
@@ -31,7 +31,7 @@ function ContactSection() {
                     body: JSON.stringify({
                         email: email,
                         message: message,
-                        token: 'fd0kAn1zns',
+                        token: '6BK2tEU6Cv',
                     }),
                 });
 

--- a/frontend/components/sections/ContactSection.tsx
+++ b/frontend/components/sections/ContactSection.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";
 import AsyncButton from '../AsyncButton';
 import { logAnalyticsEvent } from '../Analytics';
+import { API_AUTH_TOKEN } from '../../config/api';
 import styles from './ContactSection.module.css';
 
 function ContactSection() {
@@ -31,7 +32,7 @@ function ContactSection() {
                     body: JSON.stringify({
                         email: email,
                         message: message,
-                        token: '6BK2tEU6Cv',
+                        token: API_AUTH_TOKEN,
                     }),
                 });
 

--- a/frontend/components/sections/NewsletterSection.tsx
+++ b/frontend/components/sections/NewsletterSection.tsx
@@ -29,7 +29,7 @@ function NewsletterSection() {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     email: email,
-                    token: 'fd0kAn1zns',
+                    token: '6BK2tEU6Cv',
                 }),
             });
 

--- a/frontend/components/sections/NewsletterSection.tsx
+++ b/frontend/components/sections/NewsletterSection.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";
 import AsyncButton from "../AsyncButton";
 import { logAnalyticsEvent } from '../Analytics';
+import { API_AUTH_TOKEN } from '../../config/api';
 import styles from './NewsletterSection.module.css';
 
 function NewsletterSection() {
@@ -29,7 +30,7 @@ function NewsletterSection() {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     email: email,
-                    token: '6BK2tEU6Cv',
+                    token: API_AUTH_TOKEN,
                 }),
             });
 

--- a/frontend/config/api.ts
+++ b/frontend/config/api.ts
@@ -8,5 +8,9 @@
 /**
  * Authentication token used to validate requests from frontend to backend.
  * This token must match the token configured in the backend lambda_function.ts
+ *
+ * NOTE: This does NOT provide actual security (it's visible in the client-side code).
+ * It's only meant to block naive bots and scrapers who don't know about it.
+ * Do not rely on this for authentication or authorization.
  */
 export const API_AUTH_TOKEN = '6BK2tEU6Cv';

--- a/frontend/config/api.ts
+++ b/frontend/config/api.ts
@@ -1,0 +1,12 @@
+/**
+ * API Configuration
+ *
+ * This file contains configuration values for API communication between
+ * the frontend and backend services.
+ */
+
+/**
+ * Authentication token used to validate requests from frontend to backend.
+ * This token must match the token configured in the backend lambda_function.ts
+ */
+export const API_AUTH_TOKEN = '6BK2tEU6Cv';

--- a/frontend/e2e/tests/contact-form.spec.ts
+++ b/frontend/e2e/tests/contact-form.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { HomePage } from '../pages/home.page';
 import { mockContactAPI } from '../fixtures/api-mocks';
+import { API_AUTH_TOKEN } from '../../config/api';
 
 test.describe('Contact Form Flow', () => {
   let homePage: HomePage;
@@ -66,7 +67,7 @@ test.describe('Contact Form Flow', () => {
     expect(capturedRequest).toEqual({
       email: 'feedback@test.com',
       message: 'My feedback message',
-      token: '6BK2tEU6Cv',
+      token: API_AUTH_TOKEN,
     });
   });
 });

--- a/frontend/e2e/tests/contact-form.spec.ts
+++ b/frontend/e2e/tests/contact-form.spec.ts
@@ -66,7 +66,7 @@ test.describe('Contact Form Flow', () => {
     expect(capturedRequest).toEqual({
       email: 'feedback@test.com',
       message: 'My feedback message',
-      token: 'fd0kAn1zns',
+      token: '6BK2tEU6Cv',
     });
   });
 });

--- a/frontend/e2e/tests/newsletter.spec.ts
+++ b/frontend/e2e/tests/newsletter.spec.ts
@@ -65,7 +65,7 @@ test.describe('Newsletter Signup Flow', () => {
 
     expect(capturedRequest).toEqual({
       email: 'user@test.com',
-      token: 'fd0kAn1zns',
+      token: '6BK2tEU6Cv',
     });
   });
 });

--- a/frontend/e2e/tests/newsletter.spec.ts
+++ b/frontend/e2e/tests/newsletter.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { HomePage } from '../pages/home.page';
 import { mockNewsletterAPI } from '../fixtures/api-mocks';
+import { API_AUTH_TOKEN } from '../../config/api';
 
 test.describe('Newsletter Signup Flow', () => {
   let homePage: HomePage;
@@ -65,7 +66,7 @@ test.describe('Newsletter Signup Flow', () => {
 
     expect(capturedRequest).toEqual({
       email: 'user@test.com',
-      token: '6BK2tEU6Cv',
+      token: API_AUTH_TOKEN,
     });
   });
 });


### PR DESCRIPTION
Changed the authentication token used between frontend and backend from 'fd0kAn1zns' to '6BK2tEU6Cv'. This token is used to validate requests from the frontend to the backend API endpoints (contact form and newsletter signup).

Updated in:
- Backend: lambda_function.ts
- Frontend components: ContactSection.tsx, NewsletterSection.tsx
- E2E tests: contact-form.spec.ts, newsletter.spec.ts