### PR TITLE
Update Visual C++ Redistributable download link

### DIFF
--- a/frontend/components/modals/Download.tsx
+++ b/frontend/components/modals/Download.tsx
@@ -156,7 +156,7 @@ const tabs = (): TabDefinition[] => [
                         <a href="https://github.com/dokan-dev/dokany/releases">DokanY</a> (version 2.2.0 or later)
                     </li>
                     <li>
-                        <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
+                        <a href="https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2022">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
                     </li>
                 </ul>
             </>

--- a/frontend/components/modals/Download.tsx
+++ b/frontend/components/modals/Download.tsx
@@ -156,7 +156,7 @@ const tabs = (): TabDefinition[] => [
                         <a href="https://github.com/dokan-dev/dokany/releases">DokanY</a> (version 2.2.0 or later)
                     </li>
                     <li>
-                        <a href="https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
+                        <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
                     </li>
                 </ul>
             </>

--- a/frontend/components/modals/Download.tsx
+++ b/frontend/components/modals/Download.tsx
@@ -156,7 +156,7 @@ const tabs = (): TabDefinition[] => [
                         <a href="https://github.com/dokan-dev/dokany/releases">DokanY</a> (version 2.2.0 or later)
                     </li>
                     <li>
-                        <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
+                        <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
                     </li>
                 </ul>
             </>

--- a/frontend/components/modals/Download.tsx
+++ b/frontend/components/modals/Download.tsx
@@ -156,7 +156,7 @@ const tabs = (): TabDefinition[] => [
                         <a href="https://github.com/dokan-dev/dokany/releases">DokanY</a> (version 2.2.0 or later)
                     </li>
                     <li>
-                        <a href="https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2022">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
+                        <a href="https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-v14-redistributable">Microsoft Visual C++ Redistributable for Visual Studio 2022</a>
                     </li>
                 </ul>
             </>


### PR DESCRIPTION
## Summary
Updated the download link for Microsoft Visual C++ Redistributable for Visual Studio 2022 to point to the official Visual Studio downloads page.

## Changes
- Changed the Visual C++ Redistributable download link from the support.microsoft.com help article to the official visualstudio.microsoft.com downloads page
- This provides users with a more direct and up-to-date source for obtaining the required redistributable

## Details
The new link (`https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-v14-redistributable`) is the official Microsoft Visual Studio downloads page, which is more reliable and maintainable than the previous support article link.

https://claude.ai/code/session_01V88gBxX3vnwRRzrfuQtVqi