### PR TITLE
Rotate frontend/backend API token

### DIFF
--- a/backend/contact.test.ts
+++ b/backend/contact.test.ts
@@ -9,7 +9,7 @@ import { email_myself } from './email';
 const mockedEmailMyself = email_myself as jest.Mock;
 
 describe('contact send', () => {
-  const validToken = '6BK2tEU6Cv';
+  const validToken = 'KO0zZRwRBP';
 
   beforeEach(() => {
     mockedEmailMyself.mockClear();

--- a/backend/integration.test.ts
+++ b/backend/integration.test.ts
@@ -37,7 +37,7 @@ interface ContactModule {
 }
 
 describe('Integration Tests', () => {
-  const validToken = '6BK2tEU6Cv';
+  const validToken = 'KO0zZRwRBP';
   let ssmClient: MockSSMClient;
   let sesClient: MockSESClient;
   let Mailchimp: MockMailchimpType;

--- a/backend/lambda_function.test.ts
+++ b/backend/lambda_function.test.ts
@@ -9,7 +9,7 @@ import { email_myself } from './email';
 const mockedEmailMyself = email_myself as jest.Mock;
 
 describe('LambdaFunction', () => {
-  const validToken = '6BK2tEU6Cv';
+  const validToken = 'KO0zZRwRBP';
 
   beforeEach(() => {
     mockedEmailMyself.mockClear();

--- a/backend/lambda_function.ts
+++ b/backend/lambda_function.ts
@@ -9,7 +9,7 @@ import { email_myself } from './email';
  * It's only meant to block naive bots and scrapers who don't know about it.
  * Do not rely on this for authentication or authorization.
  */
-const token = '6BK2tEU6Cv';
+const token = 'KO0zZRwRBP';
 
 const cors_headers = {
   'Access-Control-Allow-Origin': 'https://www.cryfs.org',

--- a/backend/newsletter.test.ts
+++ b/backend/newsletter.test.ts
@@ -28,7 +28,7 @@ const MockMailchimp = require('@mailchimp/mailchimp_marketing').default as MockM
 const mockedEmailMyself = email_myself as jest.Mock;
 
 describe('newsletter register', () => {
-  const validToken = '6BK2tEU6Cv';
+  const validToken = 'KO0zZRwRBP';
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/frontend/config/api.ts
+++ b/frontend/config/api.ts
@@ -13,4 +13,4 @@
  * It's only meant to block naive bots and scrapers who don't know about it.
  * Do not rely on this for authentication or authorization.
  */
-export const API_AUTH_TOKEN = '6BK2tEU6Cv';
+export const API_AUTH_TOKEN = 'KO0zZRwRBP';


### PR DESCRIPTION
## Summary

Rotates the shared spam-protection token (`6BK2tEU6Cv` → `KO0zZRwRBP`) used to validate newsletter/contact requests from the frontend to the backend. This is a follow-up to the honeypot work in #195: bots are still registering by calling the backend API directly with the harvested token, so rotating it invalidates every bot that's replaying the old value.

Updated in all six places the token appears:
- `frontend/config/api.ts` — `API_AUTH_TOKEN`
- `backend/lambda_function.ts` — `token`
- Tests that reference it: `backend/newsletter.test.ts`, `backend/contact.test.ts`, `backend/integration.test.ts`, `backend/lambda_function.test.ts`

## Caveats

- **Not real security.** The token is visible in the client bundle, so a bot that re-scrapes the JS will find the new value too. Rotation only breaks bots replaying the *current* value — it's a stopgap, not a fix. The durable solution is a server-verifiable challenge (e.g. Cloudflare Turnstile).
- **Deploy frontend and backend together.** The token must match on both sides. Since they deploy independently on push to `master`, a mismatch window would reject legitimate users.
- **Cached bundles.** After deploy, visitors with the old JS bundle cached (browser/CDN) will send the old token and hit "Wrong token" until their cache refreshes. Self-healing, but worth noting.

## Testing

- Backend: 46 tests pass
- Frontend: 196 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnfXUjukq37f68bVwq3thG)_