### PR TITLE
Update backend TypeScript to 6.x (major)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,7 @@
         "eslint": "^9.0.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.2.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.0.0"
       },
       "engines": {
@@ -6846,9 +6846,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,7 @@
     "eslint": "^9.0.0",
     "jest": "^30.2.0",
     "ts-jest": "^29.2.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.0.0"
   }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -17,7 +17,8 @@
     "declaration": false,
     "outDir": "./dist",
     "rootDir": ".",
-    "lib": ["ES2024"]
+    "lib": ["ES2024"],
+    "types": ["node", "jest"]
   },
   "include": ["*.ts", "__mocks__/**/*.ts", "types/**/*.ts"],
   "exclude": ["node_modules", ".aws-sam"]


### PR DESCRIPTION
## Summary

Updates the **backend** `typescript` devDependency from `5.x` to `^6.0.3` (a major version bump). This is a single-dependency major update — all relevant peers already support TypeScript 6 (`ts-jest@29` allows `typescript <7`, `typescript-eslint@8` allows `typescript <6.1.0`), so no other dependencies need to change.

## Required code change

TypeScript 6.0 changes the default of the [`types` compiler option](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html) to an empty list, so ambient global types from `@types/*` packages are no longer auto-included. Under the previous default this project implicitly picked up the Jest and Node globals; with TS 6 the type check fails with errors like `Cannot find name 'describe' / 'test' / 'expect' / 'jest'`.

To restore the previous behavior, `backend/tsconfig.json` now sets:

```jsonc
"types": ["node", "jest"]
```

(`@types/aws-lambda` and `@types/mailchimp__mailchimp_marketing` are consumed via explicit imports, so they don't need to be listed.)

## Verification

- ✅ `npm run typecheck` (`tsc --noEmit`) passes
- ✅ `npm test` — 46 tests across 7 suites pass
- The `sam build` step bundles with esbuild's own transpiler, which is independent of the installed `typescript` package version, so the Lambda build is unaffected.

## Notes

- Frontend TypeScript is intentionally **not** touched here — it's a separate project (separate PR) and its `tsconfig.json` uses the now-deprecated `moduleResolution: "node"`, which needs its own evaluation.
- Two pre-existing backend lint warnings (`no-unnecessary-type-assertion`, `no-unsafe-member-access`) are present on `master` under TS 5 as well and are out of scope for this dependency update. Backend lint is not run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XBhxU5oUjtAd5rjWdFJhu

---
_Generated by [Claude Code](https://claude.ai/code/session_013XBhxU5oUjtAd5rjWdFJhu)_