### PR TITLE
Update frontend @types/node to 26.x (major)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "@types/gtag.js": "0.0.20",
         "@types/jest": "^30.0.0",
         "@types/mdx": "2.0.13",
-        "@types/node": "^25.0.6",
+        "@types/node": "^26.1.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/url-parse": "^1.4.11",
@@ -3170,13 +3170,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -12375,9 +12375,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "@types/gtag.js": "0.0.20",
     "@types/jest": "^30.0.0",
     "@types/mdx": "2.0.13",
-    "@types/node": "^25.0.6",
+    "@types/node": "^26.1.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/url-parse": "^1.4.11",


### PR DESCRIPTION
## What

Updates the frontend dev dependency `@types/node` from `^25.0.6` to `^26.1.0` (major version bump).

## Why

Automated dependency maintenance. This is the only frontend dependency change in this PR, per the one-major-dependency-per-PR policy.

`@types/node` provides TypeScript type definitions only — it has no runtime impact. The project runtime stays pinned to Node `22.x` (`engines.node`); as before, `@types/node` runs ahead of the runtime version, which is fine since the types are a superset.

## Verification

- `npm run build` (`next build`) — passes, type-checks all source
- `npm test` — 196 tests pass across 14 suites

No source code changes were required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEP633qnniXLaa4XycmF9R)_