### PR TITLE
Update backend @types/node to 26.x (major)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,7 @@
         "@types/aws-lambda": "^8.10.0",
         "@types/jest": "^30.0.0",
         "@types/mailchimp__mailchimp_marketing": "^3.0.22",
-        "@types/node": "^25.0.6",
+        "@types/node": "^26.1.0",
         "esbuild": "^0.27.2",
         "eslint": "^9.0.0",
         "jest": "^30.2.0",
@@ -2317,13 +2317,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6898,9 +6898,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,7 @@
     "@types/aws-lambda": "^8.10.0",
     "@types/jest": "^30.0.0",
     "@types/mailchimp__mailchimp_marketing": "^3.0.22",
-    "@types/node": "^25.0.6",
+    "@types/node": "^26.1.0",
     "esbuild": "^0.27.2",
     "eslint": "^9.0.0",
     "jest": "^30.2.0",


### PR DESCRIPTION
## What

Updates the backend dev dependency `@types/node` from `^25.0.6` to `^26.1.0` (major version bump).

## Why

Automated dependency maintenance. This is the only backend dependency change in this PR, per the one-major-dependency-per-PR policy.

`@types/node` provides TypeScript type definitions only — it has no runtime impact. The Lambda runtime stays pinned to Node `22.x` (`engines.node` / `template.yaml` `Globals.Function.Runtime`); as before, `@types/node` runs ahead of the runtime version, which is fine since the types are a superset.

## Verification

- `npm run typecheck` (`tsc --noEmit`) — passes
- `npm test` — 46 tests pass across 7 suites

No source code changes were required. (The 2 pre-existing `npm run lint` warnings are unrelated to this change and present on `master`; backend CI does not run lint.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEP633qnniXLaa4XycmF9R)_