### PR TITLE
Update frontend TypeScript to 6.x (major)

### DIFF
--- a/frontend/jest.d.ts
+++ b/frontend/jest.d.ts
@@ -1,3 +1,7 @@
+// TypeScript 6 no longer auto-includes @types packages whose name contains a
+// dot (e.g. gtag.js), so reference it explicitly to keep the global `gtag`
+// declaration (used via `window.gtag`) available across the project.
+/// <reference types="gtag.js" />
 import '@testing-library/jest-dom';
 
 declare global {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,7 @@
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.0.0"
       },
       "engines": {
@@ -12289,9 +12289,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.0.0"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,7 +20,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/frontend/types/assets.d.ts
+++ b/frontend/types/assets.d.ts
@@ -16,6 +16,11 @@ declare module '*.module.scss' {
     export default classes;
 }
 
+// Global (non-module) stylesheet imports, used only for their side effects.
+// TypeScript 6 rejects side-effect imports of modules without a declaration.
+declare module '*.css';
+declare module '*.scss';
+
 // Type declarations for image imports
 declare module '*.png' {
     const content: {


### PR DESCRIPTION
## What

Updates the frontend dev dependency `typescript` from `^5.9.3` to `^6.0.3` (major version bump). The backend was already moved to TypeScript 6 in #201; this brings the frontend in line.

## Required code changes

TypeScript 6.0 surfaced three issues that the build (`next build`, which type-checks) failed on. Each is addressed with a minimal change:

1. **`@types/gtag.js` no longer auto-included** — TS6 stopped auto-including `@types` packages whose directory name contains a dot (`gtag.js`), which dropped the global `gtag` typing used via `window.gtag(...)`. Added an explicit `/// <reference types="gtag.js" />` in `jest.d.ts` (the project's ambient-globals file). Confirmed the types resolve `window.gtag` correctly once loaded.

2. **Side-effect style imports need declarations** — TS6 rejects side-effect imports of modules without a type declaration. `pages/_app.tsx` imports `bootstrap.scss` and a fontawesome `.css` globally. Added plain `declare module '*.css'` / `'*.scss'` to `types/assets.d.ts` (the more specific `*.module.css`/`*.module.scss` declarations still win for CSS-module imports).

3. **`moduleResolution: "node"` deprecated** — `node` (node10) is deprecated in TS6 and errors. Switched to `"bundler"`, the resolution mode Next.js recommends for its bundler-based builds (pairs correctly with the existing `"module": "esnext"`). This is type-check-only and does not affect the emitted site.

## Verification

- `npm run build` (`next build`) — compiles successfully and exports the static site
- `npm test` — 196 tests pass across 14 suites
- `npm run lint` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEP633qnniXLaa4XycmF9R)_