### PR TITLE
Fix backend lint errors and run linter in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -19,6 +19,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'backend/package.json'
+          cache: npm
+          cache-dependency-path: backend/package.json
+      - name: Install Dependencies
+        working-directory: backend
+        run: npm install
+      - name: Run Linter
+        working-directory: backend
+        run: npm run lint
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -60,7 +78,7 @@ jobs:
           include-hidden-files: true
 
   deploy:
-    needs: build
+    needs: [lint, build]
     if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     environment:
       name: backend-deploy

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,6 +19,24 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'frontend/package.json'
+          cache: npm
+          cache-dependency-path: frontend/package.json
+      - name: Install Dependencies
+        working-directory: frontend
+        run: npm install
+      - name: Run Linter
+        working-directory: frontend
+        run: npm run lint
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -137,7 +155,7 @@ jobs:
           path: 'frontend/out'
 
   deploy:
-    needs: [test, test-e2e, build]
+    needs: [lint, test, test-e2e, build]
     if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     environment:
       name: github-pages

--- a/backend/lambda_function.ts
+++ b/backend/lambda_function.ts
@@ -45,7 +45,7 @@ export const LambdaFunction = (
 
       const response = await implementation(body);
       response.headers = Object.assign({}, response.headers || {}, cors_headers);
-      return response as APIGatewayProxyResult;
+      return response;
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       console.log(`Error calling function. Error message: ${errMsg}. Event: ${JSON.stringify(event)}`);

--- a/backend/newsletter.test.ts
+++ b/backend/newsletter.test.ts
@@ -24,7 +24,7 @@ interface MockMailchimpType {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const MockMailchimp = require('@mailchimp/mailchimp_marketing').default as MockMailchimpType;
+const MockMailchimp = (require('@mailchimp/mailchimp_marketing') as { default: MockMailchimpType }).default;
 const mockedEmailMyself = email_myself as jest.Mock;
 
 describe('newsletter register', () => {


### PR DESCRIPTION
## Summary

The ESLint linter was configured in both projects (`npm run lint`) but was **not run in CI**, so lint errors could land on `master` unnoticed. Running `npm run lint` surfaced two errors in the backend. This PR fixes them and wires the linter into CI for both projects.

### Lint fixes (backend)

- **`lambda_function.ts`** — removed the unnecessary `as APIGatewayProxyResult` type assertion. `LambdaResponse` is already structurally assignable to `APIGatewayProxyResult`, so the assertion tripped `@typescript-eslint/no-unnecessary-type-assertion`.
- **`newsletter.test.ts`** — `require('@mailchimp/mailchimp_marketing')` returns `any`, so accessing `.default` on it triggered `@typescript-eslint/no-unsafe-member-access`. The module is now cast to a typed shape (`{ default: MockMailchimpType }`) before `.default` is accessed.

The frontend was already lint-clean; no source changes were needed there.

### CI changes

- Added a dedicated `lint` job to `.github/workflows/frontend.yml` and `.github/workflows/backend.yml` that installs dependencies and runs `npm run lint`.
- Gated the `deploy` jobs on the new `lint` job (`needs: [lint, ...]`) so lint regressions block deployment.

## Verification

Run in `backend/`:

- `npm run lint` → passes (0 errors)
- `npm run typecheck` → passes
- `npm test` → 46 passed, 7 suites

Run in `frontend/`:

- `npm run lint` → passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuZhTRpAyfvnxAu17Xrbi5)_