### PR TITLE
Update frontend dependencies (npm update)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4565,9 +4565,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001802",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
-      "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary

Runs `npm update` on the `frontend/` project to pick up in-range (minor/patch) dependency updates. The only effect is a patch bump of the transitive `caniuse-lite` browser-compatibility data package:

- `caniuse-lite` `1.0.30001802` → `1.0.30001803`

No direct dependencies changed and no major versions were bumped. This PR contains only the effects of running `npm update`, nothing else.

## Notes

- The `backend/` project produced no genuine version upgrades from `npm update` (only lockfile dedup / cross-platform optional-binary churn), so no backend PR was created.
- Available **major** upgrades (e.g. `next` 15→16, `eslint` 9→10) are intentionally excluded from this PR per the update policy and will be handled separately once no minor updates remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiTrcMNncbWj91M8YiG4sr)_