### PR TITLE
Update backend dependencies via npm update

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.1083.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1083.0.tgz",
-      "integrity": "sha512-E011igxzu+pqklPjgXHvR+GmththFPxCAwTvAYbOcoGk/USJsakf4gZKUiHtn9SDscDMDHRBMaxwjQd4H3AfCA==",
+      "version": "3.1084.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1084.0.tgz",
+      "integrity": "sha512-Nk6FHHv4EYF4V3QS4SchdUv9k9H33vHtQGh3r+yHJz72DdWK5J75UAFjnHgkvq66Zt2rLQqpq/y7qRERCl3qxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1083.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1083.0.tgz",
-      "integrity": "sha512-1hfvo8G16GX6zk1JkzWIB9kFuoC/a9rOuucbxi1LgFuGa2gHLt8tAYmkLLlpBVMRLCZWcYR9FihyYA3jATMtEQ==",
+      "version": "3.1084.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1084.0.tgz",
+      "integrity": "sha512-LyRldNUFPS3ZDkY1D50WYBnXVf7f1hl7ifyshme5TSoWQ37jvAbeNtM92K+60VYz7WBDsqVWQ86PnUTofRmQOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2551,9 +2551,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
This PR runs `npm update` in `backend/` to pick up minor and patch version updates within the existing semver ranges (no major bumps, no `package.json` changes — only `package-lock.json`).

Direct dependency updates:
- `@aws-sdk/client-ses` 3.1083.0 → 3.1084.0
- `@aws-sdk/client-ssm` 3.1083.0 → 3.1084.0

Transitive dependency updates:
- `@ungap/structured-clone` 1.3.2 → 1.3.3
- `ignore` 7.0.5 → 7.0.6 (dev)

Verification:
- ✅ `npm run typecheck` — passes
- ✅ `npm test` — 46 tests pass
- ✅ `npm run lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015fRpb4FfgSgrfiFdw435p5)_